### PR TITLE
Fix deprecations

### DIFF
--- a/source/articles/_article.slim
+++ b/source/articles/_article.slim
@@ -16,10 +16,10 @@ article.blog-article
     aside
       nav
         .previous
-          - if article = current_article.previous_article
+          - if article = current_article.article_previous
             == link_to_article(article)
         .next
-          - if article = current_article.next_article
+          - if article = current_article.article_next
             == link_to_article(article)
 
 - masthead_image(article_image(current_article))


### PR DESCRIPTION
Fixes

> NOTE: Middleman::Sitemap::Resource#previous_article is deprecated; use article_previous instead. It will be removed on or after 2017-05-01.
> Middleman::Sitemap::Resource#previous_article called from articles/_article.slim:19.
> NOTE: Middleman::Sitemap::Resource#next_article is deprecated; use article_next instead. It will be removed on or after 2017-05-01.
> Middleman::Sitemap::Resource#next_article called from articles/_article.slim:22.

Totally bonkers naming change, from regular english to Yoda-speech, but here we are...