### PR TITLE
Goodbye Sprockets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,7 @@ gem "middleman-blog"
 gem "middleman-favicon-maker"
 gem "middleman-livereload"
 gem "middleman-minify-html"
-gem "middleman-sprockets"
 
 gem "rails-html-sanitizer", :require => false
 gem "rake"
-gem "sassc"
 gem "slim"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,9 +92,6 @@ GEM
     middleman-minify-html (3.4.1)
       htmlcompressor (~> 0.2.0)
       middleman-core (>= 3.2)
-    middleman-sprockets (4.1.1)
-      middleman-core (~> 4.0)
-      sprockets (>= 3.0)
     mini_portile2 (2.4.0)
     minitest (5.14.0)
     nokogiri (1.10.8)
@@ -122,9 +119,6 @@ GEM
     slim (4.0.1)
       temple (>= 0.7.6, < 0.9)
       tilt (>= 2.0.6, < 2.1)
-    sprockets (3.7.2)
-      concurrent-ruby (~> 1.0)
-      rack (> 1, < 3)
     temple (0.8.2)
     thor (1.0.1)
     thread_safe (0.3.6)
@@ -143,11 +137,9 @@ DEPENDENCIES
   middleman-favicon-maker
   middleman-livereload
   middleman-minify-html
-  middleman-sprockets
   rails-html-sanitizer
   rake
-  sassc
   slim
 
 BUNDLED WITH
-   1.16.1
+   1.17.3


### PR DESCRIPTION
We're fully on a Webpack asset pipeline, so we have no need for Sprockets.