### PR TITLE
Link directly to the destination URL

### DIFF
--- a/helpers/article_helpers.rb
+++ b/helpers/article_helpers.rb
@@ -47,7 +47,7 @@ module ArticleHelpers
   end
 
   def articles_path
-    blog.options.prefix
+    blog.options.prefix + "/"
   end
 
   def link_to_article(article)

--- a/source/articles/da/2016-02-15-dansk-flygtningehjaelp.html.markdown
+++ b/source/articles/da/2016-02-15-dansk-flygtningehjaelp.html.markdown
@@ -9,7 +9,7 @@ photo:
     url: https://flygtning.dk
 ---
 
-Hvert år donerer vi et beløb til en velgørende organisation, som vi synes er værd at støtte op om. Sidste år var det [kampen mod kræft](/articles/kraeftens-bekaempelse), i år er valget faldet på [Dansk Flygtningehjælp](https://flygtning.dk/).
+Hvert år donerer vi et beløb til en velgørende organisation, som vi synes er værd at støtte op om. Sidste år var det [kampen mod kræft](/articles/kraeftens-bekaempelse/), i år er valget faldet på [Dansk Flygtningehjælp](https://flygtning.dk/).
 
 READMORE
 

--- a/source/articles/da/2018-05-04-loebende-udgifter.html.markdown
+++ b/source/articles/da/2018-05-04-loebende-udgifter.html.markdown
@@ -35,7 +35,7 @@ Følgende er et konkret eksempel for en mindre forretning med en tilstedeværels
 | Transaktions emails         | [Mandrill](https://www.mandrill.com/) | 175 |
 |                             | | 5.710 |
 
-Dertil kommer løbende udgifter til [udvikling](/services/development/) og [vedligehold](/services/maintenance) af løsningen, der skal betales for annoncer og SEO - for slet ikke at tale om de driftsmæssige udgifter til advokater, kontor, medarbejdere osv osv.
+Dertil kommer løbende udgifter til [udvikling](/services/development/) og [vedligehold](/services/maintenance/) af løsningen, der skal betales for annoncer og SEO - for slet ikke at tale om de driftsmæssige udgifter til advokater, kontor, medarbejdere osv osv.
 
 
 ## Andre eksempler

--- a/source/articles/da/2019-10-25-tumlino.html.markdown
+++ b/source/articles/da/2019-10-25-tumlino.html.markdown
@@ -19,7 +19,7 @@ Som fagperson får du et udstillingsvindue til motiverede, potentielle kunder, u
 
 Som startup-virksomhed er Tumlino en interessant case. De kom til os med et spørgsmål; "vi har meget begrænsede midler, hvordan udnytter vi dem bedst med så lidt teknisk risiko som muligt?"
 
-For Tumlino blev svaret at basere deres software på [en standardløsning](/articles/standard-loesninger). Deres setup er en variant af [Sharetribe](https://sharetribe.com), som vi har udvidet og ændret de steder, hvor standardløsningen ikke var tilstrækkelig.
+For Tumlino blev svaret at basere deres software på [en standardløsning](/articles/standard-loesninger/). Deres setup er en variant af [Sharetribe](https://sharetribe.com), som vi har udvidet og ændret de steder, hvor standardløsningen ikke var tilstrækkelig.
 
 Det har givet Tumlino en kæmpe fordel i forhold til at komme i markedet og teste konceptet af, da de har været i stand til at invitere fagpersoner og brugere omkring en fuldt fungerende løsning flere måneder før, de ellers ville have kunnet.
 

--- a/source/articles/da/2019-12-06-frontlobby.html.markdown
+++ b/source/articles/da/2019-12-06-frontlobby.html.markdown
@@ -25,7 +25,7 @@ Vi har udviklet bookingsystemet i tæt samarbejde med det kontorfællesskab, vi 
 
 ## Egen medicin
 
-Det har været interessant at opleve forløbet fra den anden side af bordet for en gangs skyld. At finde ud af, hvor svært det egentligt er at <a href="/articles/fokus/" title="Det er svært at sige nej til ens egn idéer">sige "nej"</a>, hvor ondt det egentligt gør at <a href="/articles/om-at-arbejde-iterativt" title="Det må godt gøre lidt ondt at lancere">præsentere noget, der ikke er perfekt</a> og at <a href="/articles/isbjerge" title="Nogle features er meget større end man skulle tro">styre uden om isbjergene</a>.
+Det har været interessant at opleve forløbet fra den anden side af bordet for en gangs skyld. At finde ud af, hvor svært det egentligt er at <a href="/articles/fokus/" title="Det er svært at sige nej til ens egn idéer">sige "nej"</a>, hvor ondt det egentligt gør at <a href="/articles/om-at-arbejde-iterativt/" title="Det må godt gøre lidt ondt at lancere">præsentere noget, der ikke er perfekt</a> og at <a href="/articles/isbjerge/" title="Nogle features er meget større end man skulle tro">styre uden om isbjergene</a>.
 
 
 ## Prøv det

--- a/source/da/work/_gomore.html.slim
+++ b/source/da/work/_gomore.html.slim
@@ -61,8 +61,8 @@ section.international
         Her kunne #{link_to("GoMore", "https://gomore.dk")} drage fordel af
         Substance Labs erfaring med lignende udvidelser og
         internationaliseringer fra andre projekter, som fx
-        #{link_to("Eventzonen", "/work/eventzonen-dk")} og
-        #{link_to("Lokalebasen", "/work/lokalebasen")}.
+        #{link_to("Eventzonen", "/work/eventzonen-dk/")} og
+        #{link_to("Lokalebasen", "/work/lokalebasen/")}.
 
 section
   .container


### PR DESCRIPTION
We (well, Netlify) automatically redirects URLs without a slash to URLs
with a trailing slash. We might as well link directly and skip a HTTP
301 redirect request.