### PR TITLE
Use general masthead transformations for articles

### DIFF
--- a/helpers/masthead_helpers.rb
+++ b/helpers/masthead_helpers.rb
@@ -36,6 +36,13 @@ module MastheadHelpers
     end
   end
 
+  # Returns URL for a masthead-formatted image that represents the given
+  # article.
+  def masthead_image_for_article(article)
+    image = article_photo_data(article, :cloudinary)
+    masthead_image(image)
+  end
+
   # Returns image_url transformed with our masthead styling
   def masthead_image_url(image_url)
     if cloudinary_image_path?(image_url)

--- a/source/articles/_article.slim
+++ b/source/articles/_article.slim
@@ -1,5 +1,5 @@
 - set_meta_tags( \
-  :thumbnail => masthead_image_url(article_image(current_article)))
+  :thumbnail => masthead_image_for_article(current_article))
 
 - content_for :masthead do
   h1.blog-article-headline== current_article.title
@@ -22,4 +22,4 @@ article.blog-article
           - if article = current_article.article_next
             == link_to_article(article)
 
-- masthead_image(article_image(current_article))
+- masthead_image_for_article(current_article)


### PR DESCRIPTION
Specifically we want the `w_1000` transformation in the list of transformations to reduce the weight of the image.

The article_image helper is too generic and makes no assumption where the image is going to be included so we can't rely on it to limit the size of the image.