### PR TITLE
Allow Unsplash credits without links

### DIFF
--- a/source/articles/_article.slim
+++ b/source/articles/_article.slim
@@ -6,7 +6,11 @@
   .blog-article-meta
     = I18n.translate("articles.show.meta_data", :author => "Jakob", :date => I18n.localize(current_article.date.to_date, :format => :long))
   - if photo_credits = article_photo_data(current_article, "credits")
-    .photo-credits = link_to(I18n.translate("articles.show.photo_credits", :name => photo_credits[:name]), photo_credits[:url])
+    .photo-credits
+      - if photo_credits[:url]
+        = link_to(I18n.translate("articles.show.photo_credits", :name => photo_credits[:name]), photo_credits[:url])
+      - else
+        = I18n.translate("articles.show.photo_credits", :name => photo_credits[:name])
 
 article.blog-article
   .container

--- a/source/articles/da/2019-02-25-standard-loesninger.html.markdown
+++ b/source/articles/da/2019-02-25-standard-loesninger.html.markdown
@@ -6,7 +6,6 @@ photo:
   cloudinary: "v1571230095/substancelab-website/supermarket_shelf"
   credits:
     name: "Fancycrave"
-    url: https://unsplash.com/photos/5KdoPHiq3vA?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText
 ---
 
 Selv om vi er specialister i at skræddersy software til lige nøjagtigt dine forretningskrav, betyder det ikke, at vi ser "standardløsning" som et fy-ord.


### PR DESCRIPTION
Don't link to Unsplash if author has removed their profile or the photo URL.