### PR TITLE
Reduce length of homepage title

### DIFF
--- a/locales/da.yml
+++ b/locales/da.yml
@@ -43,7 +43,7 @@ da:
     blog_headline: "Seneste fra bloggen"
     contact_us: Kontaktoplysninger
     meta_description: Vi forvandler ikke-tekniske iværksætteres idéer til stabile og fremtidssikrede software løsninger, der giver overskud.
-    page_title: "Substance Lab | Programmering og vedligehold af Ruby on Rails løsninger"
+    page_title: "Programmering og vedligehold af Ruby on Rails løsninger"
     peptalk: Substance Lab er et <strong>digitalt udviklingshus</strong> som realiserer <strong>online forretningsidéer</strong>
     phone: Telefon
     the_team: Personerne bag

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -40,7 +40,7 @@ en:
     blog_headline: "Substantial articles from the blog"
     contact_us: Get in touch
     meta_description: We transform the ideas of non-technical founders into fully functional, profitable software businesses, and we love it.
-    page_title: "Substance Lab | Development and maintenance of Ruby on Rails applications"
+    page_title: "Development and maintenance of Ruby on Rails applications"
     peptalk: Handcrafted <strong>web applications</strong> and <strong>online software</strong> with a focus on <strong>simplicity</strong> and <strong>profitability</strong>
     phone: Phone
     the_team: The team


### PR DESCRIPTION
Recommendation is to keep it between 50 and 60 characters, and I am not sure we need the company name there - it's probably not a particularly important keyword...