### PR TITLE
Remove date from articles

### DIFF
--- a/source/articles/_article.slim
+++ b/source/articles/_article.slim
@@ -3,8 +3,6 @@
 
 - content_for :masthead do
   h1.blog-article-headline== current_article.title
-  .blog-article-meta
-    = I18n.translate("articles.show.meta_data", :author => "Jakob", :date => I18n.localize(current_article.date.to_date, :format => :long))
   - if photo_credits = article_photo_data(current_article, "credits")
     .photo-credits
       - if photo_credits[:url]


### PR DESCRIPTION
We're not really writing all that much any longer, and we reuse much of this content on other platforms. Having dates showing an article was written 10 years ago just distracts from the fact that the content is evergreen and still relevant.