### PR TITLE
Track .com separately from .dk

### DIFF
--- a/source/layouts/analytics.slim
+++ b/source/layouts/analytics.slim
@@ -1,1 +1,1 @@
-script defer=true data-domain="substancelab.dk" src="https://plausible.io/js/plausible.js"
+script defer=true data-domain="#{config.domain}" src="https://plausible.io/js/plausible.js"ga

--- a/source/layouts/analytics.slim
+++ b/source/layouts/analytics.slim
@@ -1,0 +1,1 @@
+script defer=true data-domain="substancelab.dk" src="https://plausible.io/js/plausible.js"

--- a/source/layouts/layout.slim
+++ b/source/layouts/layout.slim
@@ -31,7 +31,7 @@ html lang="#{current_locale}"
     link rel="shortcut icon" href="/images/favicon.png"
     link rel="icon" type="image/ico" href="/images/favicon.ico"
 
-    script defer=true data-domain="substancelab.dk" src="https://plausible.io/js/plausible.js"
+    == partial("layouts/analytics")
 
   body *body_attributes
     == partial("layouts/tag_manager/body")


### PR DESCRIPTION
Seeing what domain is actually being used in analytics is probably a good idea, especially since the current .com tracking doesn't actually work.