### PR TITLE
Add a cookie page

### DIFF
--- a/locales/da.yml
+++ b/locales/da.yml
@@ -51,6 +51,11 @@ da:
     vat_id_name: CVR-nummer
     web_application_work_by_substance_lab: Web application lavet af Substance Lab
 
+  legalese:
+    cookies:
+      meta_description: "Vi bruger cookies. Vi lover dig, at de ikke er ondsindede. Læs mere om, hvordan vi bruger cookies, og hvorfor vi bruger dem."
+      title: "Cookies"
+
   navigation:
     articles: Artikler
     home: Forside

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -48,6 +48,11 @@ en:
     vat_id_name: VAT ID
     web_application_work_by_substance_lab: Web application work by Substance Lab
 
+  legalese:
+    cookies:
+      meta_description: "We use cookies. They aren't evil, we promise. Read more about how we use cookies and why we use them."
+      title: "Cookies"
+
   navigation:
     articles: Articles
     home: Home

--- a/source/cookies.html.slim
+++ b/source/cookies.html.slim
@@ -1,0 +1,13 @@
+---
+---
+- set_meta_tags( \
+  :description => I18n.translate("legalese.cookies.meta_description"),
+  :title => I18n.translate("legalese.cookies.title"))
+
+- content_for :masthead do
+  h1== I18n.translate("legalese.cookies.title")
+
+article
+  .container
+    .content
+      div cs-declaration=true


### PR DESCRIPTION
Not because we want to, but because we have to (given that we're starting to track people using cookies)...

Using consent.studio for cookie management.

<img width="1200" height="3795" alt="Screenshot 2026-06-11 at 10-15-50 Cookies - Substance Lab" src="https://github.com/user-attachments/assets/a92e9f15-4253-4f61-9d5a-199c21511652" />



